### PR TITLE
dbus: do not include unused afxres.h on windows.

### DIFF
--- a/dbus/versioninfo.rc.in
+++ b/dbus/versioninfo.rc.in
@@ -14,7 +14,6 @@
 
 #line __LINE__ "versioninfo.rc.in"
 
-#include <afxres.h>
 
 
 VS_VERSION_INFO VERSIONINFO


### PR DESCRIPTION
Bug: https://bugs.freedesktop.org/show_bug.cgi?id=96181
Reviewed-by: simon.mcvittie@collabora.co.uk
