### PR TITLE
Update links to point to GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 This is an unofficial GitHub mirror of
-[dbus](http://cgit.freedesktop.org/dbus/dbus/), the reference implementation
+[dbus](https://gitlab.freedesktop.org/dbus/dbus/), the reference implementation
 of [D-Bus](https://wiki.freedesktop.org/www/Software/dbus/).
 It might be outdated.
 
 dbus is not developed on GitHub. Please do not send pull requests here.
 Bug reports and feature requests should be discussed on
-[the freedesktop.org Bugzilla](https://bugs.freedesktop.org/).
+[the freedesktop.org GitLab issue tracker](https://gitlab.freedesktop.org/dbus/dbus/-/issues/).


### PR DESCRIPTION
As Freedesktop development now happens on GitLab, let's update the links.